### PR TITLE
uboot removed `ro` on some partitions

### DIFF
--- a/recipes-bsp/u-boot/files/0001-HID_customizations.patch
+++ b/recipes-bsp/u-boot/files/0001-HID_customizations.patch
@@ -16,7 +16,7 @@ diff -ruN a/configs/sam9x60-hid_nandflash_defconfig b/configs/sam9x60-hid_nandfl
 +CONFIG_NAND_BOOT=y
 +CONFIG_BOOTDELAY=3
 +CONFIG_USE_BOOTARGS=y
-+CONFIG_BOOTARGS="console=ttyS0,115200 earlyprintk mtdparts=atmel_nand:256k(bootstrap)ro,768k(uboot)ro,256k(env_redundant),256k(env),256k(dtb),5M(kernel)ro,89344k(rootfs),-(data) rootfstype=ubifs ubi.mtd=6 root=ubi0:rootfs rw"
++CONFIG_BOOTARGS="console=ttyS0,115200 earlyprintk mtdparts=atmel_nand:256k(bootstrap)ro,768k(uboot),256k(env_redundant),256k(env),256k(dtb),5M(kernel),89344k(rootfs),-(data) rootfstype=ubifs ubi.mtd=6 root=ubi0:rootfs rw"
 +CONFIG_SYS_CONSOLE_IS_IN_ENV=y
 +CONFIG_MISC_INIT_R=y
 +# CONFIG_DISPLAY_BOARDINFO is not set


### PR DESCRIPTION
Removed the `ro` flag in u-boot for kernel and uboot partition